### PR TITLE
📦 v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] - _Unreleased_
+## [1.1.1] - 2020-07-10
+
+### 🐛 Fix ENOENT on Windows [#33](https://github.com/alexlee-dev/cypress-tool/issues/33)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `spawn npm ENOENT` on Windows - [#33](https://github.com/alexlee-dev/cypress-tool/issues/33)
+
 ## [1.1.0] - 2020-07-10
 
 ### 📝 Version Selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - _Unreleased_
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
 ## [1.1.0] - 2020-07-10
 
 ### 📝 Version Selection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-tool",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tool to help update/fix Cypress installs.",
   "main": "index.js",
   "bin": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { Options as boxenOptions } from "boxen";
 /**
  * Application Version
  */
-export const version = "1.1.0";
+export const version = "1.1.1";
 
 /**
  * Blank style applied to Boxen.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/node";
 Sentry.init({
   dsn:
     "https://166cfccac6334fa29750ddf656c53445@o202486.ingest.sentry.io/3668079",
-  release: "1.1.0",
+  release: "1.1.1",
 });
 
 import Configstore from "configstore";

--- a/src/util.ts
+++ b/src/util.ts
@@ -301,7 +301,11 @@ export const getAvailableVersions = async (): Promise<string[]> => {
   await executeCommand(
     "npm",
     ["show", "cypress", "versions", "-json"],
-    { env: { ...process.env } },
+    {
+      env: { ...process.env },
+      path: undefined,
+      shell: process.platform === "win32",
+    },
     (data: Buffer) => {
       availableVersions = JSON.parse(data.toString());
       availableVersions.reverse();


### PR DESCRIPTION
## [1.1.1] - 2020-07-10 

### 🐛 Fix ENOENT on Windows [#33](https://github.com/alexlee-dev/cypress-tool/issues/33)

### Added

### Changed

### Removed

### Fixed

- `spawn npm ENOENT` on Windows - [#33](https://github.com/alexlee-dev/cypress-tool/issues/33)